### PR TITLE
+- 在非windows平台上，添加脚本宏XLUA|SLUA|TOLUA会失败

### DIFF
--- a/LuaProfiler/LuaProfilerClient/Editor/StartUp.cs
+++ b/LuaProfiler/LuaProfilerClient/Editor/StartUp.cs
@@ -96,7 +96,7 @@ namespace MikuLuaProfiler
 #if UNITY_EDITOR_WIN
             path = path.Replace("Editor\\StartUp.cs", "Core\\Driver\\LuaDLL.cs");
 #else
-            path = path.Replace("Editor/StartUp.cs", "Core/LuaHookSetup.cs");
+            path = path.Replace("Editor/StartUp.cs", "Core/Driver/LuaDLL.cs");
 #endif
             AppendText(macro, selfPath);
             AppendText(macro, path);


### PR DESCRIPTION
对比windows版本，应该是加错文件了，尝试加到LuaHookSetup.cs，但没地方用到。应该是回到LuaDLL.cs才对
fix issue: DLL Macro append fail on other platform except Windows because of trying to the wrong file